### PR TITLE
Update to 3.0.1-GM-CANDIDATE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ MAINTAINER Smith Micro Software, Inc.
 LABEL Description="Swift 3 on Ubuntu 15.10"
 
 ENV UBUNTU_VERSION ubuntu15.10
-ENV SWIFT_SNAPSHOT swift-3.0-RELEASE
+ENV SWIFT_SNAPSHOT swift-3.0.1-GM-CANDIDATE
 ENV SWIFT_ARCHIVE $SWIFT_SNAPSHOT-$UBUNTU_VERSION.tar.gz
-ENV SWIFT_PATH builds/swift-3.0-release/ubuntu1510/$SWIFT_SNAPSHOT
+ENV SWIFT_PATH builds/$SWIFT_SNAPSHOT/ubuntu1510/$SWIFT_SNAPSHOT
 
 # Swift Prerequisites
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
Hi – thanks for maintaining Docker images for Swift. Attached is a PR for 3.0.1-GM-CANDIDATE (the final 3.0.1 that comes with Xcode 8.1 is not yet on swift.org). I can add another PR once 3.0.1 is out

Thanks,
Claus
